### PR TITLE
Generalize vars across cohorts 

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ######                                            ######
 #                                                      #
 #      Define all relevant parameters here             #
@@ -9,7 +11,12 @@
 
 # Remember to be consistant with directories. Always leave end blank
 
-REPO="/home/hpc2862/Scripts/phase-impute-pipe/"
-DATA_DIR="/scratch/hpc2862/CAMH/jen/NEAM"
-REF_DIR="/scratch/hpc2862/CAMH/jen/ALL.integrated_phase1_SHAPEIT_16-06-14.nomono"
-range="assets/chromosome_boundaries.txt"
+export R="/home/hpc2862/repos/impute/"
+export DD="/scratch/hpc2862/CAMH/jen/NEAM/"
+export RD="/scratch/hpc2862/CAMH/jen/ALL.integrated_phase1_SHAPEIT_16-06-14.nomono/"
+export range="assets/chromosome_boundaries.txt"
+export plink="/home/hpc2862/Programs/binary_executables/plink"
+export DATA="NEAM_QC_complete_150623"
+export shapeit="bin/shapeit"
+
+

--- a/CONFIG
+++ b/CONFIG
@@ -12,7 +12,7 @@
 # Remember to be consistant with directories. Always leave end blank
 
 export R="/home/hpc2862/repos/impute/"
-export DD="/scratch/hpc2862/CAMH/jen/PNAT_2_AA/"
+export DD="/scratch/hpc2862/CAMH/jen/PNAT2_AA/"
 export RD="/scratch/hpc2862/CAMH/jen/ALL.integrated_phase1_SHAPEIT_16-06-14.nomono/"
 export range="assets/chromosome_boundaries.txt"
 export plink="/home/hpc2862/Programs/binary_executables/plink"

--- a/CONFIG
+++ b/CONFIG
@@ -12,11 +12,11 @@
 # Remember to be consistant with directories. Always leave end blank
 
 export R="/home/hpc2862/repos/impute/"
-export DD="/scratch/hpc2862/CAMH/jen/NEAM/"
+export DD="/scratch/hpc2862/CAMH/jen/PNAT_2_AA/"
 export RD="/scratch/hpc2862/CAMH/jen/ALL.integrated_phase1_SHAPEIT_16-06-14.nomono/"
 export range="assets/chromosome_boundaries.txt"
 export plink="/home/hpc2862/Programs/binary_executables/plink"
-export DATA="NEAM_QC_complete_150623"
-export shapeit="bin/shapeit"
+export DATA="PNAT2_AA_QC_complete_150729"
+export shapeit="/home/hpc2862/repos/impute/bin/shapeit"
 
 

--- a/RUN
+++ b/RUN
@@ -15,33 +15,52 @@ source CONFIG
 # omit the exlude snps, because we only generate those after
 # the align check step.
 
+cd $DD
+#remove dups, maybe make this first?
+Rscript ${R}app/remove_dup.R $DD $DATA
+
+
 for CHR in $(seq 1 22)
 do
 
-	cd $DD
-	#remove dups, maybe make this first?
-	Rscript $R$app/remove_dup.R $DD $DATA
-
 	#local split by 
-	$plink --bfile $DATA --chr $CHR --make-bed --out $DATA_chr${CHR}
+	$plink --noweb --bfile $DATA --chr $CHR --exclude exclude_snp_list.txt --make-bed --out ${DATA}_chr${CHR}
 
 	#align check 1
-	${shapeit} -check -B ${DD}${DATA}_chr${CHR} -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --input-ref ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz ${RD}ALL.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.sample --output-log neam_alignment_chr${CHR}
+	${shapeit} -check -B ${DATA}_chr${CHR} -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --input-ref ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz ${RD}ALL.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.sample --output-log ${DATA}_alignment_chr${CHR}
 
 	#cleanup
 	#rm -f neam_alignment_chr*.log
 	#rm -f KIS3_AA_QC_complete_150731_chr*.*
 
+	# grab bad snps
+
+
+	cat ${DATA}_alignment_chr${CHR}.snp.strand | grep "Strand" | awk '{ print $3 }' > flip.chr${CHR}.txt
+
+	cat ${DATA}_alignment_chr${CHR}.snp.strand | grep "Missing" | awk '{ print $3 }' > exclude.chr${CHR}.txt
+
+	#flip these in the data
+
+	$plink --noweb --bfile ${DATA}_chr${CHR} --flip flip.chr${CHR}.txt --make-bed --out ${DATA}_chr${CHR}.flipped
+
+	#check again and pipe all problems to an exclude
+
+	${shapeit} -check -B ${DATA}_chr${CHR}.flipped -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --input-ref ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz ${RD}ALL.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.sample --output-log ${DATA}_alignment_chr${CHR}.flipped
 	
+	cat ${DATA}_alignment_chr${CHR}.flipped.snp.strand | grep "Strand" | awk '{ print $3 }' >> exclude.chr${CHR}.txt
+	cat ${DATA}_alignment_chr${CHR}.flipped.snp.strand | grep "Missing" | awk '{ print $3 }' >> exclude.chr${CHR}.txt
 
-	#this outputs exlude_snp_list.txt to $DD
+	#prephasing
 
+	qsub -N ${DATA}_chr{CHR}_prephase -V ${R}app/new_prephase.sh
 
+	#qsub this, too slow
+	#$shapeit -B ${DATA}_chr${CHR}.flipped -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --exclude-snp exclude.chr${CHR}.txt -O ${DATA}_chr${CHR}.flipped.phased
 
-
-
-
-
+	#imputation
 
 
 done
+
+

--- a/RUN
+++ b/RUN
@@ -26,7 +26,7 @@ do
 	$plink --bfile $DATA --chr $CHR --make-bed --out $DATA_chr${CHR}
 
 	#align check 1
-	${R}${shapeit} -check -B ${DD}${DATA}_chr${CHR} -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --input-ref ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz ${RD}ALL.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.sample --output-log neam_alignment_chr${CHR}
+	${shapeit} -check -B ${DD}${DATA}_chr${CHR} -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --input-ref ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz ${RD}ALL.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.sample --output-log neam_alignment_chr${CHR}
 
 	#cleanup
 	#rm -f neam_alignment_chr*.log

--- a/RUN
+++ b/RUN
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# first, remove duplicate snps
+Rscript remove_dup.R
+
+#then subset

--- a/RUN
+++ b/RUN
@@ -53,7 +53,7 @@ do
 
 	#prephasing
 
-	qsub -N ${DATA}_chr{CHR}_prephase -V ${R}app/new_prephase.sh
+	qsub -N ${DATA}_chr{CHR}_prephase -V ${R}app/new_prephase.sh $CHR
 
 done
 

--- a/RUN
+++ b/RUN
@@ -53,7 +53,7 @@ do
 
 	#prephasing
 
-	qsub -N ${DATA}_chr{CHR}_prephase -V ${R}app/new_prephase.sh $CHR
+	qsub -N ${DATA}_chr${CHR}_prephase -V ${R}app/new_prephase.sh $CHR
 
 done
 

--- a/RUN
+++ b/RUN
@@ -55,12 +55,6 @@ do
 
 	qsub -N ${DATA}_chr{CHR}_prephase -V ${R}app/new_prephase.sh
 
-	#qsub this, too slow
-	#$shapeit -B ${DATA}_chr${CHR}.flipped -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --exclude-snp exclude.chr${CHR}.txt -O ${DATA}_chr${CHR}.flipped.phased
-
-	#imputation
-
-
 done
 
 

--- a/RUN
+++ b/RUN
@@ -1,6 +1,47 @@
 #!/bin/bash
 
-# first, remove duplicate snps
-Rscript remove_dup.R
+################# !!! #####################
+#                                         #
+#         THESE ARE LOCALLY RUN           #
+#         bash run; cnt+z; disown         #
+#                                         #
+################  !!! #####################
 
-#then subset
+#source the config parms
+
+source CONFIG 
+
+# first split the chromosomes up, note that this script is modified to 
+# omit the exlude snps, because we only generate those after
+# the align check step.
+
+for CHR in $(seq 1 22)
+do
+
+	cd $DD
+	#remove dups, maybe make this first?
+	Rscript $R$app/remove_dup.R $DD $DATA
+
+	#local split by 
+	$plink --bfile $DATA --chr $CHR --make-bed --out $DATA_chr${CHR}
+
+	#align check 1
+	${R}${shapeit} -check -B ${DD}${DATA}_chr${CHR} -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --input-ref ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz ${RD}ALL.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.sample --output-log neam_alignment_chr${CHR}
+
+	#cleanup
+	#rm -f neam_alignment_chr*.log
+	#rm -f KIS3_AA_QC_complete_150731_chr*.*
+
+	
+
+	#this outputs exlude_snp_list.txt to $DD
+
+
+
+
+
+
+
+
+
+done

--- a/RUN2.sh
+++ b/RUN2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+################# !!! #####################
+#                                         #
+#         THESE ARE LOCALLY RUN           #
+#         bash run; cnt+z; disown         #
+#                                         #
+################  !!! #####################
+
+#source the config parms
+
+source CONFIG 
+
+cd /home/hpc2862/repos/impute
+
+Rscript app/m_impute.R $range

--- a/app/impute.sh
+++ b/app/impute.sh
@@ -6,7 +6,7 @@
 #$ -V
 #$ -l mf=192G
 #$ -j y
-#$ -o /home/hpc2862/logs/$JOB_NAME.txt
+#$ -o /home/hpc2862/repos/impute/logs/$JOB_NAME.txt
 
 #!/bin/bash
 

--- a/app/impute.sh
+++ b/app/impute.sh
@@ -10,8 +10,8 @@
 
 #!/bin/bash
 
-DATA_DIR="/scratch/hpc2862/CAMH/jen/NEAM"
-REF_DIR="/scratch/hpc2862/CAMH/jen/ALL.integrated_phase1_SHAPEIT_16-06-14.nomono"
+source /home/hpc2862/repos/impute/CONFIG
+#all other options come from config
 
 CHR=$1
 START=$2
@@ -22,11 +22,11 @@ OPTION=$4
 cd /home/hpc2862/Scripts/impute
 
 bin/impute2 \
--known_haps_g ${DATA_DIR}/NEAM_QC_complete_150623_chr${CHR}.flipped.phased.haps \
--h ${REF_DIR}/ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz \
--l ${REF_DIR}/ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz \
--m ${REF_DIR}/genetic_map_chr12_combined_b37.txt \
+-known_haps_g ${DD}${DATA}_chr${CHR}.flipped.phased.haps \
+-h ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.haplotypes.gz \
+-l ${RD}ALL.chr${CHR}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.nomono.legend.gz \
+-m ${RD}genetic_map_chr12_combined_b37.txt \
 -int ${START} ${STOP} \
 -Ne 15000 \
 -buffer 250 \
--o ${DATA_DIR}/NEAM_QC_complete_150623_chr${CHR}.flipped.phased.imputed.${START}.${STOP} ${OPTION}
+-o ${DD}${DATA}_chr${CHR}.flipped.phased.imputed.${START}.${STOP} ${OPTION}

--- a/app/m_impute.R
+++ b/app/m_impute.R
@@ -1,6 +1,8 @@
 #!/usr/bin/Rscript
 #read in vars
-source("CONFIG")
+
+args <- commandArgs(TRUE)
+range <- args[1]
 
 bound <- read.table(range, h = F)
 

--- a/app/m_impute.R
+++ b/app/m_impute.R
@@ -3,6 +3,7 @@
 
 args <- commandArgs(TRUE)
 range <- args[1]
+DATA <- args[2]
 
 bound <- read.table(range, h = F)
 
@@ -35,7 +36,7 @@ for(i in 1:22){
       option <- "-allow_large_regions"
     }
 
-    command <- paste0("qsub -N NEAM_", chr, "_impute_", l_range, "_", u_range, " app/impute.sh ", chr, " ", l_range, " ", u_range, " ", option)
+    command <- paste0("qsub -N ", DATA, "_", chr, "_impute_", l_range, "_", u_range, " app/impute.sh ", chr, " ", l_range, " ", u_range, " ", option)
     system(command)
 
   }

--- a/app/new_prephase.sh
+++ b/app/new_prephase.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#$ -S /bin/bash
+#$ -q abaqus.q
+#$ -l qname=abaqus.q
+#$ -cwd
+#$ -V
+#$ -j y
+#$ -o /home/hpc2862/logs/$JOB_NAME.txt
+
+cd $DD
+
+$shapeit -B ${DATA}_chr${CHR}.flipped -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --exclude-snp exclude.chr${CHR}.txt -O ${DATA}_chr${CHR}.flipped.phased

--- a/app/new_prephase.sh
+++ b/app/new_prephase.sh
@@ -8,5 +8,7 @@
 #$ -o /home/hpc2862/repos/impute/logs/$JOB_NAME.txt
 
 cd $DD
+source /home/hpc2862/repos/impute/CONFIG
+CHR=$1
 
 $shapeit -B ${DATA}_chr${CHR}.flipped -M ${RD}genetic_map_chr${CHR}_combined_b37.txt --exclude-snp exclude.chr${CHR}.txt -O ${DATA}_chr${CHR}.flipped.phased

--- a/app/new_prephase.sh
+++ b/app/new_prephase.sh
@@ -5,7 +5,7 @@
 #$ -cwd
 #$ -V
 #$ -j y
-#$ -o /home/hpc2862/logs/$JOB_NAME.txt
+#$ -o /home/hpc2862/repos/impute/logs/$JOB_NAME.txt
 
 cd $DD
 

--- a/app/remove_dup.R
+++ b/app/remove_dup.R
@@ -1,29 +1,33 @@
 #!/usr/bin/Rscript
-
 require(data.table)
 require(dplyr)
 require(tidyr)
 
-setwd("/scratch/hpc2862/CAMH/jen/NEAM")
+args <- commandArgs(trailingOnly = TRUE)
+DD <- args[1]
+DATA <- args[2]
 
-neam <- fread("NEAM_QC_complete_150623.bim")
+
+setwd(as.character(DD))
+
+df <- fread(paste0(DATA, ".bim"))
 
 #look forward, getting all the ones which are first
-dup <- neam[base::duplicated(neam$V4),]
+dup <- df[base::duplicated(df$V4),]
 exm_dup <- dup[grep("exm", dup$V2),]
 
 #look backwards, getting all the dups that are second
-dup <- neam[base::duplicated(neam$V4, fromLast=TRUE),]
+dup <- df[base::duplicated(df$V4, fromLast=TRUE),]
 exm_dup2 <- dup[grep("exm", dup$V2),]
 
 #combine together into one vector
 exclude_exm <- c(exm_dup$V2, exm_dup2$V2)
 
 #remove this list form the original data frame
-neam_no_exm <- neam[!(neam$V2 %in% exclude_exm),]
+df_no_exm <- df[!(df$V2 %in% exclude_exm),]
 
 #list the rest of the duplicates, these dont matter which order maybe.  check this
-dup3 <- neam_no_exm[base::duplicated(neam_no_exm$V4),]
+dup3 <- df_no_exm[base::duplicated(df_no_exm$V4),]
 
 #print out and write exclude list to be used with plink
 snp_list <- c(exclude_exm, dup3$V2)

--- a/app/split_by_chr.sh
+++ b/app/split_by_chr.sh
@@ -1,12 +1,4 @@
-#!/bin/bash
-#$ -S /bin/bash
-#$ -q abaqus.q
-#$ -l qname=abaqus.q
-#$ -cwd
-#$ -V
-#$ -l mf=192G
-#$ -j y
-#$ -o /home/hpc2862/logs/$JOB_NAME.txt
+
 
 cd /scratch/hpc2862/CAMH/jen/NEAM
 


### PR DESCRIPTION
Put all vars into `./CONFIG` and use `./RUN` instead of individual scripts.

Some have to be retained, i.e. `./app/remove_dup.R`.  
